### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,5 +3,6 @@ version=0.1
 author=Alonso Jose Lara Plana <alonso.lara.plana@gmail.com>
 maintainer=Alonso Jose Lara Plana <alonso.lara.plana@gmail.com>
 sentence=Arm library
+paragraph=using Adafruit compatible 16Ch Driver.
 category=Device Control
 url=https://github.com/AlonsoLP/Arduino-Arm-Library


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format